### PR TITLE
SVP support + 2 bugfixes

### DIFF
--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -195,20 +195,6 @@ function process(uuid, t, new_ranges)
     end
 end
 
--- https://stackoverflow.com/questions/9168058/how-to-dump-a-table-to-console
-function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
-end
-
 function getranges(_, exists, db, more)
     if type(exists) == "table" and exists["status"] == "1" then
         if options.server_fallback then
@@ -245,7 +231,7 @@ function getranges(_, exists, db, more)
     else
         sponsors = utils.subprocess({args = args})
     end
-    mp.msg.debug("Got: " .. dump(sponsors))
+    mp.msg.debug("Got: " .. string.gsub(sponsors.stdout, "[\n\r]", ""))
     if not string.match(sponsors.stdout, "^%s*(.*%S)") then return end
     if string.match(sponsors.stdout, "error") then return getranges(true, true) end
     local new_ranges = {}
@@ -398,9 +384,9 @@ function file_loaded()
     last_skip = {uuid = "", dir = nil}
     chapter_cache = {}
     local video_path = mp.get_property("path")
-    mp.msg.debug("Path: " .. video_path)
+    mp.msg.debug("Path: " .. video_path or "")
     local video_referer = string.match(mp.get_property("http-header-fields"), "Referer:([^,]+)")
-    mp.msg.debug("Referer: " .. video_referer)
+    mp.msg.debug("Referer: " .. video_referer or "")
 
     local urls = {
         "https?://youtu%.be/([%w-_]+).*",
@@ -416,7 +402,7 @@ function file_loaded()
     
     if not youtube_id or string.len(youtube_id) < 11 or (local_pattern and string.len(youtube_id) ~= 11) then return end
     youtube_id = string.sub(youtube_id, 1, 11)
-    mp.msg.info("Found YouTube ID: " .. youtube_id)
+    mp.msg.debug("Found YouTube ID: " .. youtube_id)
     init = true
     if not options.local_database then
         getranges(true, true)

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -383,10 +383,10 @@ function file_loaded()
     segment = {a = 0, b = 0, progress = 0, first = true}
     last_skip = {uuid = "", dir = nil}
     chapter_cache = {}
-    local video_path = mp.get_property("path")
-    mp.msg.debug("Path: " .. video_path or "")
-    local video_referer = string.match(mp.get_property("http-header-fields"), "Referer:([^,]+)")
-    mp.msg.debug("Referer: " .. video_referer or "")
+    local video_path = mp.get_property("path") or ""
+    mp.msg.debug("Path: " .. video_path)
+    local video_referer = string.match(mp.get_property("http-header-fields") or "", "Referer:([^,]+)")
+    mp.msg.debug("Referer: " .. video_referer)
 
     local urls = {
         "https?://youtu%.be/([%w-_]+).*",

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -402,20 +402,18 @@ function file_loaded()
     local video_referer = string.match(mp.get_property("http-header-fields"), "Referer:([^,]+)")
     mp.msg.debug("Referer: " .. video_referer)
 
-    local youtube_id1 = string.match(video_path, "https?://youtu%.be/([%w-_]+).*")
-    local youtube_id2 = string.match(video_path, "https?://w?w?w?%.?youtube%.com/v/([%w-_]+).*")
-    local youtube_id3 = string.match(video_path, "/watch.*[?&]v=([%w-_]+).*")
-    local youtube_id4 = string.match(video_path, "/embed/([%w-_]+).*")
-    local youtube_idr1 = string.match(video_referer, "https?://youtu%.be/([%w-_]+).*")
-    local youtube_idr2 = string.match(video_referer, "https?://w?w?w?%.?youtube%.com/v/([%w-_]+).*")
-    local youtube_idr3 = string.match(video_referer, "/watch.*[?&]v=([%w-_]+).*")
-    local youtube_idr4 = string.match(video_referer, "/embed/([%w-_]+).*")
-    local local_pattern = nil
-    if options.local_pattern ~= "" then
-        local_pattern = string.match(video_path, options.local_pattern)
+    local urls = {
+        "https?://youtu%.be/([%w-_]+).*",
+        "https?://w?w?w?%.?youtube%.com/v/([%w-_]+).*",
+        "/watch.*[?&]v=([%w-_]+).*",
+        "/embed/([%w-_]+).*"
+    }
+    youtube_id = nil
+    for i,url in ipairs(urls) do 
+        youtube_id = youtube_id or string.match(video_path, url) or string.match(video_referer, url)
     end
-    youtube_id = youtube_id1 or youtube_id2 or youtube_id3 or youtube_id4 or 
-                 youtube_idr1 or youtube_idr2 or youtube_idr3 or youtube_idr4 or local_pattern
+    youtube_id = youtube_id or string.match(video_path, options.local_pattern)
+    
     if not youtube_id or string.len(youtube_id) < 11 or (local_pattern and string.len(youtube_id) ~= 11) then return end
     youtube_id = string.sub(youtube_id, 1, 11)
     mp.msg.info("Found YouTube ID: " .. youtube_id)

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -406,12 +406,16 @@ function file_loaded()
     local youtube_id2 = string.match(video_path, "https?://w?w?w?%.?youtube%.com/v/([%w-_]+).*")
     local youtube_id3 = string.match(video_path, "/watch.*[?&]v=([%w-_]+).*")
     local youtube_id4 = string.match(video_path, "/embed/([%w-_]+).*")
-    local youtube_id5 = string.match(video_referer, "/watch.*[?&]v=([%w-_]+).*")
+    local youtube_idr1 = string.match(video_referer, "https?://youtu%.be/([%w-_]+).*")
+    local youtube_idr2 = string.match(video_referer, "https?://w?w?w?%.?youtube%.com/v/([%w-_]+).*")
+    local youtube_idr3 = string.match(video_referer, "/watch.*[?&]v=([%w-_]+).*")
+    local youtube_idr4 = string.match(video_referer, "/embed/([%w-_]+).*")
     local local_pattern = nil
     if options.local_pattern ~= "" then
         local_pattern = string.match(video_path, options.local_pattern)
     end
-    youtube_id = youtube_id1 or youtube_id2 or youtube_id3 or youtube_id4 or youtube_id5 or local_pattern
+    youtube_id = youtube_id1 or youtube_id2 or youtube_id3 or youtube_id4 or 
+                 youtube_idr1 or youtube_idr2 or youtube_idr3 or youtube_idr4 or local_pattern
     if not youtube_id or string.len(youtube_id) < 11 or (local_pattern and string.len(youtube_id) ~= 11) then return end
     youtube_id = string.sub(youtube_id, 1, 11)
     mp.msg.info("Found YouTube ID: " .. youtube_id)

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -296,10 +296,10 @@ function skip_ads(name, pos)
         if (options.fast_forward == uuid or not options.skip_once or not t.skipped) and t.start_time <= pos and t.end_time > pos then
             if options.fast_forward == uuid then return end
             if options.fast_forward == false then
-                mp.osd_message("[sponsorblock] sponsor skipped")
+                mp.osd_message("[sponsorblock] " .. t.category .. " skipped")
                 mp.set_property("time-pos", t.end_time)
             else
-                mp.osd_message("[sponsorblock] skipping sponsor")
+                mp.osd_message("[sponsorblock] skipping " .. t.category)
             end
             t.skipped = true
             last_skip = {uuid = uuid, dir = nil}

--- a/sponsorblock.lua
+++ b/sponsorblock.lua
@@ -383,9 +383,9 @@ function file_loaded()
     segment = {a = 0, b = 0, progress = 0, first = true}
     last_skip = {uuid = "", dir = nil}
     chapter_cache = {}
-    local video_path = mp.get_property("path") or ""
+    local video_path = mp.get_property("path", "")
     mp.msg.debug("Path: " .. video_path)
-    local video_referer = string.match(mp.get_property("http-header-fields") or "", "Referer:([^,]+)")
+    local video_referer = string.match(mp.get_property("http-header-fields", ""), "Referer:([^,]+)") or ""
     mp.msg.debug("Referer: " .. video_referer)
 
     local urls = {

--- a/sponsorblock_shared/sponsorblock.py
+++ b/sponsorblock_shared/sponsorblock.py
@@ -86,16 +86,16 @@ elif sys.argv[1] == "update":
         os.replace(sys.argv[2] + ".tmp", sys.argv[2])
     except PermissionError:
         print("database update failed, file currently in use", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
     except ConnectionResetError:
         print("database update failed, connection reset", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
     except TimeoutError:
         print("database update failed, timed out", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
     except urllib.error.URLError:
         print("database update failed", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 elif sys.argv[1] == "submit":
     try:
         req = urllib.request.Request(sys.argv[3] + "/api/skipSegments", data=json.dumps({"videoID": sys.argv[4], "segments": [{"segment": [float(sys.argv[5]), float(sys.argv[6])], "category": sys.argv[9]}], "userID": uid}).encode(), headers={"Content-Type": "application/json"})


### PR DESCRIPTION
With the youtube-dl configuration [SVP](https://www.svp-team.com/) uses, `path` contains the direct googlevideo.com url, while the youtube video link with the video ID is in `http-header-fields`. This adds another pattern match to check if this is the case.

Additional changes:
- sponsorblock.py was using `exit` instead of `sys.exit` which generated an unhandled exception on DB update failure
- OSD message now displays the category of the skipped segment, not just 'sponsor'
- Added some debugging messages to mpv's log file